### PR TITLE
feat: support wordpress.com website

### DIFF
--- a/blog/.env.sample
+++ b/blog/.env.sample
@@ -1,1 +1,6 @@
+# The root of WordPress REST API
 WP_API=http://localhost/wp-json
+
+# If you use wordpress.com, uncomment and use the below env var instead.
+# Note: Do not include 'https://' or trailing slash.
+# WP_COM_DOMAIN=yourblog0123456789.wordpress.com

--- a/blog/utils/wp.ts
+++ b/blog/utils/wp.ts
@@ -12,12 +12,18 @@ if (WP_COM_DOMAIN) {
 } else if (WP_API) {
   console.log("Using WP_API=" + WP_API);
 } else {
-  console.log("WP_API or WP_COM_DOMAIN env vars are not set. Using default WP_API (http://localhost/wp-json)")
+  console.log(
+    "WP_API or WP_COM_DOMAIN env vars are not set. Using default WP_API (http://localhost/wp-json)",
+  );
   WP_API = "http://localhost/wp-json";
 }
 
-const WP_API_ROOT = WP_COM_DOMAIN ? `https://public-api.wordpress.com/wp/v2/sites/${WP_COM_DOMAIN}` : WP_API + "/wp/v2"
-const SITE_INFO_API = WP_API ? WP_API : `https://public-api.wordpress.com/rest/v1.1/sites/${WP_COM_DOMAIN}`;
+const WP_API_ROOT = WP_COM_DOMAIN
+  ? `https://public-api.wordpress.com/wp/v2/sites/${WP_COM_DOMAIN}`
+  : WP_API + "/wp/v2";
+const SITE_INFO_API = WP_API
+  ? WP_API
+  : `https://public-api.wordpress.com/rest/v1.1/sites/${WP_COM_DOMAIN}`;
 
 export type WpPost = WP.WP_REST_API_Post;
 export type WpCategory = WP.WP_REST_API_Category;
@@ -48,7 +54,7 @@ export async function callApi<T = unknown>(
 }
 
 export async function getSiteName() {
-  const resp = await fetch(SITE_INFO_API!)
+  const resp = await fetch(SITE_INFO_API!);
   return (await resp.json())?.name || "Untitled";
 }
 

--- a/blog/utils/wp.ts
+++ b/blog/utils/wp.ts
@@ -33,8 +33,10 @@ export async function callApi<T = unknown>(
   const WP_API = (overwriteUrl)
     ? overwriteUrl
     : (!IS_WPCOM)
-      ? `${WP_DOMAIN}/wp-json/wp/v2`
-      : `https://public-api.wordpress.com/wp/v2/sites/${new URL(WP_DOMAIN).hostname}`
+    ? `${WP_DOMAIN}/wp-json/wp/v2`
+    : `https://public-api.wordpress.com/wp/v2/sites/${
+      new URL(WP_DOMAIN).hostname
+    }`;
   const resp = await fetch(WP_API + path, options);
   return [await resp.json() as T, {
     total: toNum(resp.headers.get("x-wp-total")),
@@ -45,8 +47,18 @@ export async function callApi<T = unknown>(
 
 export async function getSiteName() {
   const [{ name }] = (!IS_WPCOM)
-    ? await callApi<{ name: string }>("/?fields=name", undefined, `${WP_DOMAIN}/wp-json`)
-    : await callApi<{ name: string }>("/?fields=name", undefined, `https://public-api.wordpress.com/rest/v1.1/sites/${new URL(WP_DOMAIN).hostname}`);
+    ? await callApi<{ name: string }>(
+      "/?fields=name",
+      undefined,
+      `${WP_DOMAIN}/wp-json`,
+    )
+    : await callApi<{ name: string }>(
+      "/?fields=name",
+      undefined,
+      `https://public-api.wordpress.com/rest/v1.1/sites/${
+        new URL(WP_DOMAIN).hostname
+      }`,
+    );
   return name;
 }
 
@@ -73,8 +85,7 @@ export function getPostsByCategoryId(
   page: number,
   categoryId: number,
 ): Promise<[WpPost[], WpResponseMetadata]> {
-  const path =
-    `/posts?page=${page}&categories=${categoryId}&${listQuery}`;
+  const path = `/posts?page=${page}&categories=${categoryId}&${listQuery}`;
   return callApi<WpPost[]>(path);
 }
 

--- a/blog/utils/wp.ts
+++ b/blog/utils/wp.ts
@@ -54,7 +54,7 @@ export async function callApi<T = unknown>(
 }
 
 export async function getSiteName() {
-  const resp = await fetch(SITE_INFO_API!);
+  const resp = await fetch(SITE_INFO_API + "/?fields=name");
   return (await resp.json())?.name || "Untitled";
 }
 

--- a/blog/utils/wp.ts
+++ b/blog/utils/wp.ts
@@ -13,7 +13,7 @@ if (WP_COM_DOMAIN) {
   console.log("Using WP_API=" + WP_API);
 } else {
   console.log(
-    "WP_API or WP_COM_DOMAIN env vars are not set. Using default WP_API (http://localhost/wp-json)",
+    "WP_API and WP_COM_DOMAIN env vars are not set. Using default WP_API (http://localhost/wp-json)",
   );
   WP_API = "http://localhost/wp-json";
 }


### PR DESCRIPTION
1. Add the wordpress.com website support as well, but its REST API URL & endpoint are both different from self-hosted WP. Consider the easy setup, try to use `WP_DOMAIN` (Sorry for renaming the `WP_API` but I think the naming is better understanding) and `IS_WPCOM` two env variables to control the switching.

2. WP.com has another problem while fetching the website name. In self-hosted WP, we can get the information by using `/wp-json?fields=name` but WP.com only returns API discovery data. We need to use [WP.com API (v1.1)](https://developer.wordpress.com/docs/api/) instead and it's also different from 1. the WP.com REST API endpoint. So I added another optional parameter `overwriteUrl` within `callApi`.